### PR TITLE
Enable autosquash when rebasing.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+## Master (unreleased)
+
+* Enable autosquash mode when rebasing by default.
+
 ## 0.4.0 - 2014-02-20
 
 * Prevent merging when the target branch is different from origin. Prevents

--- a/git_pretty_accept.gemspec
+++ b/git_pretty_accept.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rspec-example_steps'
+  spec.add_development_dependency 'rspec', '~> 2.14.0'
+  spec.add_development_dependency 'rspec-example_steps', '~> 0.2.5'
 end

--- a/lib/git_pretty_accept/app.rb
+++ b/lib/git_pretty_accept/app.rb
@@ -11,13 +11,16 @@ module GitPrettyAccept
         exit!
       else
         options[:edit] = true if options[:edit].nil?
-        Transaction.new(branch, options[:edit]).call
+        options[:autosquash] = true if options[:autosquash].nil?
+
+        Transaction.new(branch, options).call
       end
     end
 
     description "Accept pull requests, the pretty way"
 
     on "--[no-]edit", "Edit merge message before committing. (Default: --edit)"
+    on "--[no-]autosquash", "Toggle autosquash when rebasing. (Default: --autosquash)"
 
     arg :branch
 

--- a/spec/git_pretty_accept/app_spec.rb
+++ b/spec/git_pretty_accept/app_spec.rb
@@ -98,7 +98,7 @@ describe GitPrettyAccept::App do
     end
 
     When 'I run `git pretty-accept master`' do
-      command = "bundle exec #{project_path}/bin/git-pretty-accept --no-edit master"
+      command = "bundle exec #{project_path}/bin/git-pretty-accept --no-edit --no-autosquash master"
       FileUtils.cd(our_path) do
         @result = system(command, err: '/tmp/err.log')
       end
@@ -238,7 +238,7 @@ describe GitPrettyAccept::App do
 
     When 'I run `git pretty-accept PR_BRANCH`' do
       command =
-        "bundle exec #{project_path}/bin/git-pretty-accept --no-edit #{pr_branch}"
+        "bundle exec #{project_path}/bin/git-pretty-accept --no-edit --no-autosquash #{pr_branch}"
 
       FileUtils.cd(our_path) do
         @result = system(command, err: '/tmp/err.log')

--- a/spec/support/local_repo.rb
+++ b/spec/support/local_repo.rb
@@ -44,7 +44,7 @@ class LocalRepo
 
   def git_pretty_accept(branch)
     FileUtils.cd(path) do
-      puts `bundle exec #{project_path}/bin/git-pretty-accept --no-edit #{branch}`
+      puts `bundle exec #{project_path}/bin/git-pretty-accept --no-edit --no-autosquash #{branch}`
     end
   end
 


### PR DESCRIPTION
@htanata @gsmendoza It's my attempts to enable autosquash for git_pretty_accept. I imitated the original implementation, added `-i --autosquash` at the last rebase command. 

But I found it was a bit hard to test autosquash mode. The git gem didn't provide a `git commit --fixup` option (see here: https://github.com/schacon/ruby-git/blob/master/lib/git/base.rb#L292). And do you have a good idea to test the interactive mode of rebasing? I guess that we maybe need to simulate some keyboard input? 

