### PR TITLE
Update Methadone to 1.9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ before_script:
 script: bundle exec rspec
 rvm:
   - 2.2.3
+  - 2.4.0
 cache: bundler

--- a/git_pretty_accept.gemspec
+++ b/git_pretty_accept.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'git'
-  spec.add_dependency 'methadone', '~> 1.3.1'
+  spec.add_dependency 'methadone', '~> 1.9'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'guard'


### PR DESCRIPTION
In order to support Ruby 2.4. See https://github.com/davetron5000/methadone/releases/tag/v1.9.5.

**Note**: This is dependent on https://github.com/lovewithfood/git_pretty_accept/pull/8.