### PR TITLE
Update supported Ruby to 2.2.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,5 @@ before_script:
   - git config --global user.name "Your Name"
 script: bundle exec rspec
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - rbx
+  - 2.2.3
 cache: bundler

--- a/README.md
+++ b/README.md
@@ -55,11 +55,6 @@ script
 1. Rebases the local branch in interactive mode so that it can run
   autosquash(See `--autosquash` under http://git-scm.com/docs/git-rebase#_options).
 
-## Known to be working on
-
-* git 2.3.3
-* ruby 2.0.0
-
 ## Contributing
 
 1. Fork it

--- a/git_pretty_accept.gemspec
+++ b/git_pretty_accept.gemspec
@@ -35,4 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 2.14.0'
   spec.add_development_dependency 'rspec-example_steps', '~> 0.2.5'
+
+  # Must set version in order to run 'bundle update'.
+  # Can be removed once upgraded to ruby >= 2.2.5
+  # https://github.com/e2/ruby_dep
+  spec.add_development_dependency 'ruby_dep', '~> 1.3.1'
 end

--- a/spec/git_pretty_accept/app_spec.rb
+++ b/spec/git_pretty_accept/app_spec.rb
@@ -185,9 +185,16 @@ describe GitPrettyAccept::App do
     end
 
     And 'both local and remote PR branch have been updated' do
+      # Delay commit of local_pr_message by 1 full second. Git gem
+      # seems to be confused when commits are too close to each other.
+      sleep 1
       local_repo.commit_some_change local_pr_message
 
       other_repo.checkout pr_branch
+
+      # Delay commit of remote_pr_message by 1 full second. Git gem
+      # seems to be confused when commits are too close to each other.
+      sleep 1
       other_repo.push_some_change remote_pr_message
     end
 
@@ -208,9 +215,7 @@ describe GitPrettyAccept::App do
       expect(local_repo.git.log[1].message).to eq(local_pr_message)
       expect(local_repo.git.log[1].parents.size).to eq(1)
 
-      # For some reason, the order of the logs 2 and 3 is indeterminate.
-      expect(local_repo.git.log[2 .. 3].map(&:message).sort)
-        .to include(remote_pr_message)
+      expect(local_repo.git.log[2].message).to eq(remote_pr_message)
     end
   end
 


### PR DESCRIPTION
It's been a while since we last updated this gem. We need to get it passing on CI again based on the current Ruby we're using.